### PR TITLE
Using sets to lower time complexity on general pruning

### DIFF
--- a/aigyminsper/search/SearchAlgorithms.py
+++ b/aigyminsper/search/SearchAlgorithms.py
@@ -44,8 +44,8 @@ class BuscaLargura (SearchAlgorithm):
         if pruning not in valid_pruning_options:
             raise ValueError(f"Invalid pruning option: {pruning}. Valid options are {valid_pruning_options}")
 
-        # List to keep track of the visited nodes
-        states = []
+        # Set to keep track of the visited nodes
+        states = set()
         #Creating a Queue
         open = deque()
         open.append(Node(initialState, None))
@@ -65,7 +65,7 @@ class BuscaLargura (SearchAlgorithm):
                 # general pruning
                 elif pruning == "general" and (new_n.state.env() not in states):
                     open.append(new_n)
-                    states.append(new_n.state.env())
+                    states.add(new_n.state.env())
         return None
 
 
@@ -80,8 +80,8 @@ class BuscaProfundidade (SearchAlgorithm):
         if pruning not in valid_pruning_options:
             raise ValueError(f"Invalid pruning option: {pruning}. Valid options are {valid_pruning_options}")
 
-        # List to keep track of the visited nodes
-        states = []
+        # Set to keep track of the visited nodes
+        states = set()
         #Using list as stack
         open = []
         open.append(Node(initialState, None))
@@ -102,7 +102,7 @@ class BuscaProfundidade (SearchAlgorithm):
                     # general pruning
                     elif pruning == "general" and (new_n.state.env() not in states):
                         open.append(new_n)
-                        states.append(new_n.state.env())
+                        states.add(new_n.state.env())
         return None
 
 class BuscaProfundidadeIterativa (SearchAlgorithm):
@@ -131,8 +131,8 @@ class BuscaCustoUniforme (SearchAlgorithm):
         if pruning not in valid_pruning_options:
             raise ValueError(f"Invalid pruning option: {pruning}. Valid options are {valid_pruning_options}")
 
-        # List to keep track of the visited nodes
-        states = []
+        # Set to keep track of the visited nodes
+        states = set()
         open = []
         new_n = Node(initialState, None)
         open.append((new_n, new_n.g))
@@ -154,7 +154,7 @@ class BuscaCustoUniforme (SearchAlgorithm):
                 # general pruning
                 elif pruning == "general" and (new_n.state.env() not in states):
                     open.append((new_n, new_n.g))
-                    states.append(new_n.state.env())
+                    states.add(new_n.state.env())
         return None
     
 
@@ -169,8 +169,8 @@ class BuscaGananciosa (SearchAlgorithm):
         if pruning not in valid_pruning_options:
             raise ValueError(f"Invalid pruning option: {pruning}. Valid options are {valid_pruning_options}")
 
-        # List to keep track of the visited nodes
-        states = []
+        # Set to keep track of the visited nodes
+        states = set()
         open = []
         new_n = Node(initialState, None)
         open.append((new_n, new_n.h()))
@@ -192,7 +192,7 @@ class BuscaGananciosa (SearchAlgorithm):
                 # general pruning
                 elif pruning == "general" and (new_n.state.env() not in states):
                     open.append((new_n, new_n.h()))
-                    states.append(new_n.state.env())
+                    states.add(new_n.state.env())
         return None
 
 
@@ -207,8 +207,8 @@ class AEstrela (SearchAlgorithm):
         if pruning not in valid_pruning_options:
             raise ValueError(f"Invalid pruning option: {pruning}. Valid options are {valid_pruning_options}")
 
-        # List to keep track of the visited nodes
-        states = []
+        # Set to keep track of the visited nodes
+        states = set()
         open = []
         new_n = Node(initialState, None)
         open.append((new_n, new_n.f()))
@@ -234,5 +234,5 @@ class AEstrela (SearchAlgorithm):
                     open.append((new_n,new_n.f()))
                     # nao eh adiciona o estado ao vetor.
                     # eh adicionado o conteudo
-                    states.append(new_n.state.env())
+                    states.add(new_n.state.env())
         return None


### PR DESCRIPTION
Hi @fbarth,

In this pull request, I:

- Changed all `states` variables from lists to sets, improving the performance of verifying if a state is in states from `O(N)` to `O(1)` (see the example below for a performance comparison).
- Updated the code comments to reflect these changes.

### Performance Comparison

Using the `SumOne(1, '', 100_000)` environment with the `BuscaLargura` algorithm and `pruning='general'`:

**Before:**
```sh
time python tests/SumOne.py
```
Output: `"python tests/SumOne.py  61.15s user 0.07s system 99% cpu 1:01.23 total"`

**After:**
```sh
time python tests/SumOne.py
```
Output: `"python tests/SumOne.py  0.31s user 0.00s system 99% cpu 0.312 total"`

This change significantly reduces the execution time, making the algorithm more efficient.

Please let me know if you would like any adjustments.